### PR TITLE
Add Yum / Pacman / Paru as package managers

### DIFF
--- a/casaos.sh
+++ b/casaos.sh
@@ -194,6 +194,12 @@ install_depends() {
             $sudo_cmd dnf install $packagesNeeded
         elif [ -x "$(command -v zypper)" ]; then
             $sudo_cmd zypper install $packagesNeeded
+        elif [ -x "$(command -v yum)" ]; then
+            $sudo_cmd yum install $packagesNeeded
+        elif [ -x "$(command -v pacman)" ]; then
+            $sudo_cmd pacman -S $packagesNeeded
+        elif [ -x "$(command -v paru)" ]; then
+            $sudo_cmd paru -S $packagesNeeded
         else
             show 1 "Package manager not found. You must manually install: $packagesNeeded"
         fi


### PR DESCRIPTION
Hey while instaling CasaOs on Arch I noticed it wasn't finding my package manager (Paru) I decided to contribute to the install script by adding the dependency install command for the Yum, Packman and Paru package managers.
Hope this helps !