### PR TITLE
Added Trisquel linux to recognized OSes.

### DIFF
--- a/casaos.sh
+++ b/casaos.sh
@@ -54,6 +54,7 @@ readonly PHYSICAL_MEMORY=$(LC_ALL=C free -m | awk '/Mem:/ { print $2 }')
 readonly FREE_DISK_BYTES=$(LC_ALL=C df -P / | tail -n 1 | awk '{print $4}')
 readonly FREE_DISK_GB=$((${FREE_DISK_BYTES} / 1024 / 1024))
 readonly LSB_DIST="$(. /etc/os-release && echo "$ID")"
+readonly LSB_DIST_LIKE="$(. /etc/os-release && echo "$ID_LIKE")"
 readonly UNAME_M="$(uname -m)"
 readonly UNAME_U="$(uname -s)"
 
@@ -264,6 +265,9 @@ Check_Distribution() {
     *alpine*)
         Show 1 "Aborted, Alpine installation is not yet supported."
         exit 1
+        ;;
+    *trisquel*)
+        Target_Distro="debian"
         ;;
     *)
         sType=1

--- a/get.sh
+++ b/get.sh
@@ -222,6 +222,9 @@ Check_Distribution() {
         Show 1 "Aborted, Alpine installation is not yet supported."
         exit 1
         ;;
+    *trisquel*)
+        Target_Distro="debian"
+        ;;
     *)
         sType=1
         notice="We have not tested it on this system and it may fail to install."

--- a/install.sh
+++ b/install.sh
@@ -222,6 +222,9 @@ Check_Distribution() {
         Show 1 "Aborted, Alpine installation is not yet supported."
         exit 1
         ;;
+    *trisquel*)
+        Target_Distro="debian"
+        ;;
     *)
         sType=1
         notice="We have not tested it on this system and it may fail to install."

--- a/update.sh
+++ b/update.sh
@@ -224,6 +224,9 @@ Check_Distribution() {
         Show 1 "Aborted, Alpine installation is not yet supported."
         exit 1
         ;;
+    *trisquel*)
+        Target_Distro="debian"
+        ;;
     *)
         sType=1
         notice="We have not tested it on this system and it may fail to install."

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -224,6 +224,9 @@ Check_Distribution() {
         Show 1 "Aborted, Alpine installation is not yet supported."
         exit 1
         ;;
+    *trisquel*)
+        Target_Distro="debian"
+        ;;
     *)
         sType=1
         notice="We have not tested it on this system and it may fail to install."


### PR DESCRIPTION
The Trisquel is a DEBIAN Like distro so this can be treated like that.

According to /etc/os-release ID_LIKE parameter the Trisquel GNU Linux is a Debian like distro, so I added trisquel linux option on the distro validation on all the install/update/upgrade scripts of CasaOS. 

I've tested the new version script on my server with the chage and the script worked good in it.

Any question contact me please.